### PR TITLE
changed LocationsRowItem from state to usState - fixed display error

### DIFF
--- a/launchtrip-ui/src/App.jsx
+++ b/launchtrip-ui/src/App.jsx
@@ -3,7 +3,7 @@ import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
 import { ItinerariesPage } from './components/Itineraries/ItinerariesPage'
-import { LocationsPage } from './components/locations/LocationsPage'
+import { LocationsPage } from './components/Locations/LocationsPage'
 
 function App() {
   const [count, setCount] = useState(0)

--- a/launchtrip-ui/src/components/locations/LocationsRowItem.jsx
+++ b/launchtrip-ui/src/components/locations/LocationsRowItem.jsx
@@ -5,7 +5,7 @@ export const LocationsRowItem = ({ location, deleteLocation }) => {
     <tr key={location.id}>
       <th scope="row">{location.id}</th>
       <td>{location.name}</td>
-      <td>{location.state}</td>
+      <td>{location.usState}</td>
       <td>{location.country}</td>
       <td>{location.postcode}</td>
       <td>{location.categories.join(", ")}</td>


### PR DESCRIPTION
States weren't displaying in Locations list - it was due to a naming error. In the backend I refer to the state as usState because IntelliJ warned me that "state" as a variable name had some overlap. Frontend was looking for "state" and not "usState" and thus not displaying. Fixed!