### PR TITLE
added ManyToOne user property to Itineraries class

### DIFF
--- a/launchtrip-api/src/main/java/com/launchtrip/launchtrip/models/Itinerary.java
+++ b/launchtrip-api/src/main/java/com/launchtrip/launchtrip/models/Itinerary.java
@@ -17,6 +17,10 @@ public class Itinerary {
     @OneToMany
     private List<Location> locations = new ArrayList<>();
 
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
     public Itinerary() {
     }
 


### PR DESCRIPTION
After merging the new User class and associated files, we had a build error because the User class was trying to link to Itineraries without a matching property in the Itinerary class. Updated that by adding property to Itinerary class!