### PR TITLE
Added a 'Paid' field to the location object. 

### DIFF
--- a/launchtrip-api/src/main/java/com/launchtrip/launchtrip/models/Location.java
+++ b/launchtrip-api/src/main/java/com/launchtrip/launchtrip/models/Location.java
@@ -22,6 +22,7 @@ public class Location {
     private String postcode;
     private List<String> categories;
     private boolean visited;
+    private boolean paid;
 
     public Location() {
     }
@@ -35,6 +36,7 @@ public class Location {
         this.postcode = postcode;
         this.categories = categories;
         this.visited = false;
+        this.paid = true; //Default value of true unless GeoAPIFy shows that it's free
     }
 
     public Long getId() {
@@ -103,6 +105,14 @@ public class Location {
 
     public void setVisited(boolean visited) {
         this.visited = visited;
+    }
+
+    public boolean isPaid() {
+        return paid;
+    }
+
+    public void setPaid(boolean paid) {
+        this.paid = paid;
     }
 }
 

--- a/launchtrip-api/src/main/java/com/launchtrip/launchtrip/services/SearchService.java
+++ b/launchtrip-api/src/main/java/com/launchtrip/launchtrip/services/SearchService.java
@@ -122,6 +122,20 @@ public class SearchService {
                         }
 
                         Location location = new Location(name, city, placeId, usState, country, postcode, categories);
+                        /*Added by Brett. Check to see if the location has a 'no_fee.no' attribute or a 'fee' attribute*/
+                        if (categories.contains("fee"))
+                        {
+                            location.setPaid(true);
+                        }
+                        else if (categories.contains("no_fee.no")) {
+                            location.setPaid(false);
+                        }
+                        else {
+                            //Attribute 'fee' and 'no_fee.no' doesn't exist.
+                            //Just assume that its 
+                            location.setPaid(true);
+                        }
+
                         locations.add(location);
                     }
                 }

--- a/launchtrip-ui/src/components/locations/LocationCard.jsx
+++ b/launchtrip-ui/src/components/locations/LocationCard.jsx
@@ -17,9 +17,9 @@ export const LocationCard = ({ location }) => {
           <strong>Country:</strong> {location.country} <br />
           <strong>Postcode:</strong> {location.postcode} <br />
           <strong>Categories:</strong> {location.categories.join(", ")} <br />
-          {/* Added a button so a location can be added to the itinerary  */}
-          {/* <button className="btn btn-primary" onClick={() => addLocationToItinerary(itineraryId, location.id)}>Add</button> */}
-          
+          {/* Show a field for paid/free */}
+          <strong>Paid:</strong> {location.paid ? "Paid Attraction" : "Free Attraction"} <br />
+
           <button className="btn btn-danger" onClick={() => markLocationAsVisited(location.id)}>
           {location.visited ? 'Visited' : 'Unseen'} </button>
         </p>


### PR DESCRIPTION
To populate the Paid field I am checking GeoApify to see if the location has a 'fee' or 'no_fee.no' field. There might be a better way to do this but this seems to work. Sometimes a location doesn't have a 'fee' or 'no_fee' field at all and in that situation the Location object is set to paid.